### PR TITLE
chore: migrate to Dagger-based testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,0 @@
----
-jobs:
-  bake-ansible-images-v1:
-    uses: andrewrothstein/.github/.github/workflows/bake-ansible-images-v1.yml@develop
-'on': push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,7 @@
+name: Test Ansible Role
+on: [push, pull_request]
+
+jobs:
+  test:
+    uses: andrewrothstein/docker-ansible/.github/workflows/dagger-ansible-test-role.yml@develop
+    secrets: inherit


### PR DESCRIPTION
This PR migrates the repository to use Dagger for testing Ansible roles.

Changes:
- Replace traditional CI with Dagger-based workflows  
- Use reusable workflow from docker-ansible repository
- Enable multi-platform testing capabilities

Benefits:
- Faster CI execution with better caching
- Consistent testing across all roles
- Support for multiple OS and architecture combinations

Related: andrewrothstein/docker-ansible#43